### PR TITLE
Fix period raising exceptions in __eq__()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed ISO week dates not being parsed properly in `fom_format()`.
+- Fixed period `==` comparison raising an exception when compared with other types.
 
 
 ## [2.0.4] - 2018-10-30

--- a/pendulum/period.py
+++ b/pendulum/period.py
@@ -372,8 +372,11 @@ class Period(Duration):
         return hash((self.start, self.end, self._absolute))
 
     def __eq__(self, other):
-        return (self.start, self.end, self._absolute) == (
-            other.start,
-            other.end,
-            other._absolute,
-        )
+        try:
+            return (self.start, self.end, self._absolute) == (
+                other.start,
+                other.end,
+                other._absolute,
+            )
+        except AttributeError:
+            return NotImplemented

--- a/tests/period/test_behavior.py
+++ b/tests/period/test_behavior.py
@@ -40,3 +40,11 @@ def test_comparison_to_timedelta():
     period = dt2 - dt1
 
     assert period < timedelta(days=4)
+
+def test_comparison_with_other():
+    dt1 = pendulum.datetime(2016, 11, 18)
+    dt2 = pendulum.datetime(2016, 11, 20)
+    p = pendulum.period(dt1, dt2)
+
+    assert p != None
+    assert not p == None


### PR DESCRIPTION
`Period` can raise an AttributeError when being compared with other types.

e.g. 
``` pycon
>>> import pendulum
>>> p = pendulum.now() - pendulum.yesterday()
>>> p == None
AttributeError: 'NoneType' object has no attribute 'start'
>>> # should return False
```

This fix retains the same duck-typing capabilities, but using `isinstance()` is another option.