### PR TITLE
Adding try/except workaround when Pendulum tries to treat environment variable local timezone as a filepath

### DIFF
--- a/pendulum/tz/local_timezone.py
+++ b/pendulum/tz/local_timezone.py
@@ -248,7 +248,11 @@ def _tz_from_env(tzenv):  # type: (str) -> Timezone
 
     # TZ specifies a file
     if os.path.exists(tzenv):
-        return TimezoneFile(tzenv)
+        try:
+            return TimezoneFile(tzenv)
+        except FileNotFoundError:
+            # if cannot load from timezone file, assume path existing is coincidence
+            pass
 
     # TZ specifies a zoneinfo zone.
     try:

--- a/tests/tz/test_local_timezone.py
+++ b/tests/tz/test_local_timezone.py
@@ -10,6 +10,16 @@ from pendulum.tz.local_timezone import _get_windows_timezone
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Test only available for UNIX systems"
 )
+def test_unix_environment_variable(monkeypatch):
+    # localtime can be set on unix with TZ environment variable
+    monkeypatch.setenv("TZ", "UTC")
+    tz = _get_unix_timezone()
+    assert tz.name == "UTC"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Test only available for UNIX systems"
+)
 def test_unix_symlink():
     # A ZONE setting in the target path of a symbolic linked localtime,
     # f ex systemd distributions


### PR DESCRIPTION
## Pull Request Check List

Addresses bug https://github.com/sdispater/pendulum/issues/467. Adding try/except workaround in `local_timezone.py` and test for the environment variable functionality. When `pendulum` incorrectly tries to treat an environment variable local timezone as a filepath instead of a string, carry on and try to treat the string as a timezone itself, instead.

- [x] Added **tests** for changed code - one new test illustrating env var behavior, asserting it still works
- [x] Updated **documentation** for changed code - added a single-line comment explaining change, nothing to add to docs
- [x] Based on `master` because this is a bugfix for current production `pendulum==2.1.0`