### PR TITLE
Add Duration.isoformat()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2
@@ -68,6 +69,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2
@@ -112,6 +114,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ setup.py
 # editor
 
 .vscode
+
+# dev
+
+.venv

--- a/docs/docs/duration.md
+++ b/docs/docs/duration.md
@@ -175,3 +175,22 @@ It also has a handy `in_words()` method, which determines the duration represent
 >>> it.in_words(locale='de')
 '168 Wochen 1 Tag 2 Stunden 1 Minute 24 Sekunden'
 ```
+
+Finally, it has an
+[ISO-8601-compliant](https://en.wikipedia.org/wiki/ISO_8601#Durations) `isformat()`
+method for cross-platform representation.
+
+```python
+
+>>> import pendulum
+
+>>> dur = pendulum.duration(years=1, months=3, days=6, seconds=3)
+
+>>> iso = dur.isoformat()
+
+>>> print(iso)
+'P1Y3M6DT0H0M3S'
+
+>>> pendulum.parse(iso) == dur
+True
+```

--- a/pendulum/__init__.py
+++ b/pendulum/__init__.py
@@ -251,7 +251,10 @@ def yesterday(tz="local"):  # type: (Union[str, _Timezone]) -> DateTime
 
 
 def from_format(
-    string, fmt, tz=UTC, locale=None,  # noqa
+    string,
+    fmt,
+    tz=UTC,
+    locale=None,  # noqa
 ):  # type: (str, str, Union[str, _Timezone], Optional[str]) -> DateTime
     """
     Creates a DateTime instance from a specific format.

--- a/pendulum/duration.py
+++ b/pendulum/duration.py
@@ -423,7 +423,7 @@ class Duration(timedelta):
         ]
         period = "P"
         for sym, val in periods:
-            period += f"{val}{sym}"
+            period += "{val}{sym}".format(val=val, sym=sym)
         times = [
             ("H", self.hours),
             ("M", self.minutes),
@@ -431,10 +431,10 @@ class Duration(timedelta):
         ]
         time = "T"
         for sym, val in times:
-            time += f"{val}{sym}"
+            time += "{val}{sym}".format(val=val, sym=sym)
         if self.microseconds:
             time = time[:-1]
-            time += f".{self.microseconds:06}S"
+            time += ".{ms:06}S".format(ms=self.microseconds)
         return period + time
 
 

--- a/pendulum/duration.py
+++ b/pendulum/duration.py
@@ -414,6 +414,29 @@ class Duration(timedelta):
 
         return NotImplemented
 
+    def isoformat(self) -> str:
+        """Represent this duration as a ISO-8601-compliant string."""
+        periods = [
+            ("Y", self.years),
+            ("M", self.months),
+            ("D", self.remaining_days),
+        ]
+        period = "P"
+        for sym, val in periods:
+            period += f"{val}{sym}"
+        times = [
+            ("H", self.hours),
+            ("M", self.minutes),
+            ("S", self.remaining_seconds),
+        ]
+        time = "T"
+        for sym, val in times:
+            time += f"{val}{sym}"
+        if self.microseconds:
+            time = time[:-1]
+            time += f".{self.microseconds:06}S"
+        return period + time
+
 
 Duration.min = Duration(days=-999999999)
 Duration.max = Duration(

--- a/tests/datetime/test_from_format.py
+++ b/tests/datetime/test_from_format.py
@@ -39,7 +39,8 @@ def test_from_format_with_timezone():
 def test_from_format_with_square_bracket_in_timezone():
     with pytest.raises(ValueError, match="^String does not match format"):
         pendulum.from_format(
-            "1975-05-21 22:32:11 Eu[rope/London", "YYYY-MM-DD HH:mm:ss z",
+            "1975-05-21 22:32:11 Eu[rope/London",
+            "YYYY-MM-DD HH:mm:ss z",
         )
 
 

--- a/tests/duration/test_isoformat.py
+++ b/tests/duration/test_isoformat.py
@@ -1,24 +1,24 @@
 import pytest
 
-from pendulum import Duration, parse
+from pendulum import Duration
+from pendulum import parse
 
 
 @pytest.mark.parametrize(
     "dur, expected_iso",
     [
         (
-                Duration(
-                    years=1,
-                    months=3,
-                    days=6,
-                    minutes=50,
-                    seconds=3,
-                    milliseconds=10,
-                    microseconds=10,
-                ),
-                "P1Y3M6DT0H50M3.010010S",
+            Duration(
+                years=1,
+                months=3,
+                days=6,
+                minutes=50,
+                seconds=3,
+                milliseconds=10,
+                microseconds=10,
+            ),
+            "P1Y3M6DT0H50M3.010010S",
         ),
-
         (Duration(days=4, hours=12, minutes=30, seconds=5), "P0Y0M4DT12H30M5S"),
         (Duration(days=4, hours=12, minutes=30, seconds=5), "P0Y0M4DT12H30M5S"),
         (Duration(microseconds=10), "P0Y0M0DT0H0M0.000010S"),

--- a/tests/duration/test_isoformat.py
+++ b/tests/duration/test_isoformat.py
@@ -1,0 +1,32 @@
+import pytest
+
+from pendulum import Duration, parse
+
+
+@pytest.mark.parametrize(
+    "dur, expected_iso",
+    [
+        (
+                Duration(
+                    years=1,
+                    months=3,
+                    days=6,
+                    minutes=50,
+                    seconds=3,
+                    milliseconds=10,
+                    microseconds=10,
+                ),
+                "P1Y3M6DT0H50M3.010010S",
+        ),
+
+        (Duration(days=4, hours=12, minutes=30, seconds=5), "P0Y0M4DT12H30M5S"),
+        (Duration(days=4, hours=12, minutes=30, seconds=5), "P0Y0M4DT12H30M5S"),
+        (Duration(microseconds=10), "P0Y0M0DT0H0M0.000010S"),
+        (Duration(milliseconds=1), "P0Y0M0DT0H0M0.001000S"),
+        (Duration(minutes=1), "P0Y0M0DT0H1M0S"),
+    ],
+)
+def test_isoformat(dur, expected_iso):
+    fmt = dur.isoformat()
+    assert fmt == expected_iso
+    assert parse(fmt) == dur


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

This adds a simple method to represent Durations in ISO format. Given that pendulum can parse ISO 8601 strings into Durations, it makes sense that we'd be able to also serialize the other way.
