### PR TITLE
add is_business_day method to date

### DIFF
--- a/pendulum/date.py
+++ b/pendulum/date.py
@@ -26,7 +26,6 @@ from .period import Period
 
 
 class Date(FormattableMixin, date):
-
     # Names of days of the week
     _days = {
         SUNDAY: "Sunday",
@@ -216,6 +215,33 @@ class Date(FormattableMixin, date):
     # the alias is provided to start using a new name and keep the backward compatibility
     # the old name can be completely replaced with the new in one of the future versions
     is_birthday = is_anniversary
+
+    def is_business_day(self, holidays: [list, tuple] = None) -> bool:
+        """
+        Check if the date is a business day (not a weekend), including checking against an optional list of holidays
+
+        :param holidays: list or tuple containing Date or DateTime objects to be considered holidays
+        :type holidays: list, tuple
+
+        :rtype: bool
+            True if the date is a business day, otherwise false
+        """
+
+        # check if this date is a weekend
+        if self.day_of_week == SATURDAY \
+                or self.day_of_week == SUNDAY:
+            return False
+
+        # check if this date falls on a holiday
+        if holidays is not None:
+            # TODO: prefilter the holiday list by year (test for speed)
+            for holiday in holidays:
+                if self.is_same_day(holiday):
+                    return False
+
+            return False
+
+        return True
 
     # ADDITIONS AND SUBSTRACTIONS
 

--- a/tests/date/test_comparison.py
+++ b/tests/date/test_comparison.py
@@ -243,3 +243,14 @@ def test_comparison_to_unsupported():
 
     assert not dt1 == "test"
     assert dt1 not in ["test"]
+
+
+def test_is_business_day():
+    dt1 = pendulum.Date(2021, 11, 13)  # weekend
+    dt2 = pendulum.Date(2021, 11, 15)  # not weekend
+
+    holidays = [pendulum.Date(2020, 11, 15)]
+
+    assert not dt1.is_business_day()
+    assert dt2.is_business_day()
+    assert not dt2.is_business_day(holidays=holidays)


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

Add functionality to `Date` class to determine if a date is a business day with `is_business_day`. There is an optional `holidays` parameter that allows the user to input a list of dates that swill be treated as holidays and therefore not business days. 

Not included in this Pull Request (yet), but this lays the groundwork for a future addition that also include business day concept in the Period class, e.g. looping through period with a `````business_days_only=True````` flag

