### PR TITLE
In months fix

### DIFF
--- a/pendulum/_extensions/_helpers.c
+++ b/pendulum/_extensions/_helpers.c
@@ -824,14 +824,6 @@ PyObject *precise_diff(PyObject *self, PyObject *args)
                 day_diff += days_in_last_month;
             }
         }
-        else if (day_diff == days_in_month - days_in_last_month)
-        {
-            // We have exactly a full month
-            // We remove the days difference
-            // and add one to the months difference
-            day_diff = 0;
-            month_diff += 1;
-        }
         else
         {
             // We have a full month

--- a/tests/date/test_diff.py
+++ b/tests/date/test_diff.py
@@ -17,6 +17,7 @@ def setup():
     pendulum.week_starts_at(pendulum.MONDAY)
     pendulum.week_ends_at(pendulum.SUNDAY)
 
+
 @pytest.fixture
 def today():
     return pendulum.today().date()

--- a/tests/date/test_diff.py
+++ b/tests/date/test_diff.py
@@ -151,12 +151,6 @@ def test_diff_for_humans_now_and_month():
         assert "4 weeks ago" == today.subtract(weeks=4).diff_for_humans()
 
 
-def _test_pendulum_test():
-    with pendulum.test(pendulum.datetime(2016, 3, 1)):
-        today = pendulum.today().date()
-        assert today == pendulum.datetime(2016, 3, 1).date()
-
-
 def test_diff_for_humans_now_and_months(today):
     assert "2 months ago" == today.subtract(months=2).diff_for_humans()
 

--- a/tests/date/test_diff.py
+++ b/tests/date/test_diff.py
@@ -5,6 +5,18 @@ import pytest
 import pendulum
 
 
+@pytest.fixture(autouse=True)
+def setup():
+    pendulum.set_local_timezone(pendulum.timezone("UTC"))
+
+    yield
+
+    pendulum.set_test_now()
+    pendulum.set_locale("en")
+    pendulum.set_local_timezone()
+    pendulum.week_starts_at(pendulum.MONDAY)
+    pendulum.week_ends_at(pendulum.SUNDAY)
+
 @pytest.fixture
 def today():
     return pendulum.today().date()
@@ -136,7 +148,13 @@ def test_diff_for_humans_now_and_month():
     with pendulum.test(pendulum.datetime(2017, 2, 28)):
         today = pendulum.today().date()
 
-        assert "1 month ago" == today.subtract(weeks=4).diff_for_humans()
+        assert "4 weeks ago" == today.subtract(weeks=4).diff_for_humans()
+
+
+def _test_pendulum_test():
+    with pendulum.test(pendulum.datetime(2016, 3, 1)):
+        today = pendulum.today().date()
+        assert today == pendulum.datetime(2016, 3, 1).date()
 
 
 def test_diff_for_humans_now_and_months(today):
@@ -189,7 +207,7 @@ def test_diff_for_humans_now_and_future_month():
     with pendulum.test(pendulum.datetime(2017, 3, 31)):
         today = pendulum.today().date()
 
-        assert "in 1 month" == today.add(months=1).diff_for_humans()
+        assert "in 4 weeks" == today.add(months=1).diff_for_humans()
 
     with pendulum.test(pendulum.datetime(2017, 4, 30)):
         today = pendulum.today().date()
@@ -199,7 +217,7 @@ def test_diff_for_humans_now_and_future_month():
     with pendulum.test(pendulum.datetime(2017, 1, 31)):
         today = pendulum.today().date()
 
-        assert "in 1 month" == today.add(weeks=4).diff_for_humans()
+        assert "in 4 weeks" == today.add(weeks=4).diff_for_humans()
 
 
 def test_diff_for_humans_now_and_future_months(today):
@@ -252,7 +270,7 @@ def test_diff_for_humans_other_and_month():
     with pendulum.test(pendulum.datetime(2017, 3, 31)):
         today = pendulum.today().date()
 
-        assert "1 month before" == today.diff_for_humans(today.add(months=1))
+        assert "4 weeks before" == today.diff_for_humans(today.add(months=1))
 
     with pendulum.test(pendulum.datetime(2017, 4, 30)):
         today = pendulum.today().date()
@@ -262,7 +280,7 @@ def test_diff_for_humans_other_and_month():
     with pendulum.test(pendulum.datetime(2017, 1, 31)):
         today = pendulum.today().date()
 
-        assert "1 month before" == today.diff_for_humans(today.add(weeks=4))
+        assert "4 weeks before" == today.diff_for_humans(today.add(weeks=4))
 
 
 def test_diff_for_humans_other_and_months(today):
@@ -315,7 +333,7 @@ def test_diff_for_humans_other_and_future_month():
     with pendulum.test(pendulum.datetime(2017, 2, 28)):
         today = pendulum.today().date()
 
-        assert "1 month after" == today.diff_for_humans(today.subtract(weeks=4))
+        assert "4 weeks after" == today.diff_for_humans(today.subtract(weeks=4))
 
 
 def test_diff_for_humans_other_and_future_months(today):

--- a/tests/duration/test_in_methods.py
+++ b/tests/duration/test_in_methods.py
@@ -1,5 +1,6 @@
-import pendulum
 import pytest
+
+import pendulum
 
 
 def test_in_weeks():
@@ -29,22 +30,22 @@ def test_in_seconds():
 
 @pytest.mark.parametrize("month", range(1, 13))
 def test_in_months_one_year_less_a_day(month):
-    start = pendulum.parse(f"2022-{str(month).zfill(2)}-02")
-    end = pendulum.parse(f"2023-{str(month).zfill(2)}-01")  # One year less a day
+    start = pendulum.datetime(2022, month, 2).date()
+    end = pendulum.datetime(2023, month, 1).date()  # One year less a day
     assert (end - start).in_months() == 11
 
 
 @pytest.mark.parametrize("month", range(1, 13))
 def test_in_months_one_year(month):
-    start = pendulum.parse(f"2022-{str(month).zfill(2)}-01")
-    end = pendulum.parse(f"2023-{str(month).zfill(2)}-01")  # One year exactly
+    start = pendulum.datetime(2022, month, 1).date()
+    end = pendulum.datetime(2023, month, 1).date()  # One year exactly
     assert (end - start).in_months() == 12
 
 
 @pytest.mark.parametrize("day", range(1, 29))
 def test_in_months_february(day):
-    start = pendulum.parse(f"2022-02-04")
-    end_1 = pendulum.parse(f"2023-02-{str(day).zfill(2)}")
+    start = pendulum.datetime(2022, 2, 4).date()
+    end_1 = pendulum.datetime(2023, 2, day).date()
     end_2 = end_1.add(days=1)
     m_diff_1 = (end_1 - start).in_months()
     m_diff_2 = (end_2 - start).in_months()

--- a/tests/duration/test_in_methods.py
+++ b/tests/duration/test_in_methods.py
@@ -1,4 +1,5 @@
 import pendulum
+import pytest
 
 
 def test_in_weeks():
@@ -24,3 +25,27 @@ def test_in_minutes():
 def test_in_seconds():
     it = pendulum.duration(seconds=72)
     assert it.in_seconds() == 72
+
+
+@pytest.mark.parametrize("month", range(1, 13))
+def test_in_months_one_year_less_a_day(month):
+    start = pendulum.parse(f"2022-{str(month).zfill(2)}-02")
+    end = pendulum.parse(f"2023-{str(month).zfill(2)}-01")  # One year less a day
+    assert (end - start).in_months() == 11
+
+
+@pytest.mark.parametrize("month", range(1, 13))
+def test_in_months_one_year(month):
+    start = pendulum.parse(f"2022-{str(month).zfill(2)}-01")
+    end = pendulum.parse(f"2023-{str(month).zfill(2)}-01")  # One year exactly
+    assert (end - start).in_months() == 12
+
+
+@pytest.mark.parametrize("day", range(1, 29))
+def test_in_months_february(day):
+    start = pendulum.parse(f"2022-02-04")
+    end_1 = pendulum.parse(f"2023-02-{str(day).zfill(2)}")
+    end_2 = end_1.add(days=1)
+    m_diff_1 = (end_1 - start).in_months()
+    m_diff_2 = (end_2 - start).in_months()
+    assert m_diff_1 <= m_diff_2


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

This is to address issue #606. The change to the `setup` fixture in the `test_diff` module to use UTC instead of Toronto is a workaround for issue #608.

Not sure whether this should be based on `develop` or `master`. Some of this is clearly a bug (see February in particular), but some of the side effects are changes in user-facing behavior of what pendulum thinks "1 month" means colloquially, e.g. whether March 31st to April 30th is 1 month (forward), and whether April 30th to March 31st is 1 month (backward).

Rather than try to tweak the logic to satisfy the current notions of what "1 month" means, I let them change and updated the tests to match the new behavior.