### PR TITLE
fix: `pendulum.parse` is not marked as exported

### DIFF
--- a/src/pendulum/__init__.py
+++ b/src/pendulum/__init__.py
@@ -29,7 +29,7 @@ from pendulum.helpers import set_locale
 from pendulum.helpers import week_ends_at
 from pendulum.helpers import week_starts_at
 from pendulum.interval import Interval
-from pendulum.parser import parse
+from pendulum.parser import parse as parse
 from pendulum.testing.traveller import Traveller
 from pendulum.time import Time
 from pendulum.tz import UTC


### PR DESCRIPTION
This PR fixes #595, by re-exporting `parse()`. 

`parse()` should be re-exported so that the user can just call `pendulum.parse()` as documented, given that the module is marked with `py.typed`. 

No tests have been modified or added for this bugfix.