### PR TITLE
Fix pendulum.parse('now', tz='...') ignoring the time zone

### DIFF
--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -46,7 +46,7 @@ def _parse(
     """
     # Handling special cases
     if text == "now":
-        return pendulum.now()
+        return pendulum.now(tz=options.get("tz", UTC))
 
     parsed = base_parse(text, **options)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -128,8 +128,13 @@ def test_parse_interval() -> None:
 
 
 def test_parse_now() -> None:
-    dt = pendulum.parse("now")
+    assert pendulum.parse("now").timezone_name == "UTC"
+    assert (
+        pendulum.parse("now", tz="America/Los_Angeles").timezone_name
+        == "America/Los_Angeles"
+    )
 
+    dt = pendulum.parse("now", tz="local")
     assert dt.timezone_name == "America/Toronto"
 
     mock_now = pendulum.yesterday()


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code (nothing to update - as far as I can tell this isn't mentioned in it).

Previously, using "now" with `pendulum.parse` short-circuited all other parsing logic (expected), including the time zone (not expected).

Example using the latest release:
```python
>>> import pendulum
>>> pendulum.__version__
'2.1.2'
>>> pendulum.parse("2023-04-04", tz="America/Los_Angeles").format("z (Z)")
'America/Los_Angeles (-07:00)'
>>> pendulum.parse("now", tz="America/Los_Angeles").format("z (Z)")
'Etc/UTC (-00:00)'
```

The same example after this PR:
```python
>>> import pendulum
>>> pendulum.__version__
'3.0.0a'
>>> pendulum.parse("2023-04-04", tz="America/Los_Angeles").format("z (Z)")
'America/Los_Angeles (-07:00)'
>>> pendulum.parse("now", tz="America/Los_Angeles").format("z (Z)")
'America/Los_Angeles (-07:00)'
```