### PR TITLE
local_timezone: gracefully handle retrieval errors on Darwin

### DIFF
--- a/src/pendulum/tz/local_timezone.py
+++ b/src/pendulum/tz/local_timezone.py
@@ -146,9 +146,17 @@ else:
 
 
 def _get_darwin_timezone() -> Timezone:
-    # link will be something like /usr/share/zoneinfo/America/Los_Angeles.
-    link = os.readlink("/etc/localtime")
-    tzname = link[link.rfind("zoneinfo/") + 9 :]
+    try:
+        # link will be something like /usr/share/zoneinfo/America/Los_Angeles.
+        link = os.readlink("/etc/localtime")
+        tzname = link[link.rfind("zoneinfo/") + 9 :]
+    except Exception:
+        warnings.warn(
+            "Unable to find any timezone configuration, defaulting to UTC.",
+            stacklevel=1,
+        )
+
+        return UTC
 
     return Timezone(tzname)
 


### PR DESCRIPTION
In some sandbox environments, the program may not have permission to access /etc/localtime or it may not exist.

Catch any exceptions accessing and parsing its value and return UTC by default to avoid crashing the program.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
