### PR TITLE
Fix `pendulum.tz.timezones()` to use system tzdata

### DIFF
--- a/src/pendulum/tz/__init__.py
+++ b/src/pendulum/tz/__init__.py
@@ -26,7 +26,7 @@ _timezones = None
 _tz_cache: dict[int, FixedTimezone] = {}
 
 
-def timezones() -> tuple[str, ...]:
+def timezones() -> set[str]:
     return available_timezones()
 
 

--- a/src/pendulum/tz/__init__.py
+++ b/src/pendulum/tz/__init__.py
@@ -10,6 +10,7 @@ from pendulum.tz.local_timezone import test_local_timezone
 from pendulum.tz.timezone import UTC
 from pendulum.tz.timezone import FixedTimezone
 from pendulum.tz.timezone import Timezone
+from zoneinfo import available_timezones
 
 
 if TYPE_CHECKING:
@@ -26,13 +27,7 @@ _tz_cache: dict[int, FixedTimezone] = {}
 
 
 def timezones() -> tuple[str, ...]:
-    global _timezones
-
-    if _timezones is None:
-        with cast("Path", resources.files("tzdata").joinpath("zones")).open() as f:
-            _timezones = tuple(tz.strip() for tz in f.readlines())
-
-    return _timezones
+    return available_timezones()
 
 
 def fixed_timezone(offset: int) -> FixedTimezone:

--- a/src/pendulum/tz/__init__.py
+++ b/src/pendulum/tz/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from importlib import resources
-from typing import TYPE_CHECKING
-from typing import cast
+from zoneinfo import available_timezones
 
 from pendulum.tz.local_timezone import get_local_timezone
 from pendulum.tz.local_timezone import set_local_timezone
@@ -10,11 +8,6 @@ from pendulum.tz.local_timezone import test_local_timezone
 from pendulum.tz.timezone import UTC
 from pendulum.tz.timezone import FixedTimezone
 from pendulum.tz.timezone import Timezone
-from zoneinfo import available_timezones
-
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 PRE_TRANSITION = "pre"

--- a/src/pendulum/tz/__init__.py
+++ b/src/pendulum/tz/__init__.py
@@ -21,8 +21,6 @@ PRE_TRANSITION = "pre"
 POST_TRANSITION = "post"
 TRANSITION_ERROR = "error"
 
-_timezones = None
-
 _tz_cache: dict[int, FixedTimezone] = {}
 
 

--- a/src/pendulum/tz/__init__.py
+++ b/src/pendulum/tz/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cache
 from zoneinfo import available_timezones
 
 from pendulum.tz.local_timezone import get_local_timezone
@@ -17,6 +18,7 @@ TRANSITION_ERROR = "error"
 _tz_cache: dict[int, FixedTimezone] = {}
 
 
+@cache
 def timezones() -> set[str]:
     return available_timezones()
 


### PR DESCRIPTION
Fix the `pendulum.tz.available_timezones()` to use `available_timezones()` function instead of iterating over the files in `tzdata` package.  This is more in line with PEP 615, as the system timezone functions will operate on system-provided tzdata when available, and use the `tzdata` package only if it's not available. Therefore, the previous code would yield a potentially different list of timezones than the system actually provides.

Furthermore, Gentoo provides a dummy `tzdata` package that does not provide any data, since Python always uses system tzdata.  This change is necessary to make pendulum work again on Gentoo.

Fixes #769

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
