### PR TITLE
Avoid usage of deprecated `datetime.datetime.utcfromtimestamp` in `pendulum.from_timestamp`

### DIFF
--- a/src/pendulum/__init__.py
+++ b/src/pendulum/__init__.py
@@ -292,11 +292,7 @@ def from_timestamp(timestamp: int | float, tz: str | Timezone = UTC) -> DateTime
     """
     Create a DateTime instance from a timestamp.
     """
-    dt = _datetime.datetime.utcfromtimestamp(timestamp)
-
-    dt = datetime(
-        dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond
-    )
+    dt = DateTime.fromtimestamp(timestamp, tz=UTC)
 
     if tz is not UTC or tz != "UTC":
         dt = dt.in_timezone(tz)


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

`datetime.datetime.utcfromtimestamp()` is deprecated into the [Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#deprecated) as result current implementation raise warning message

```console
/usr/local/lib/python3.12/site-packages/pendulum/__init__.py:295 DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC:
```