### PR TITLE
Remove direct dependency on tzdata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 
 dependencies = [
     "python-dateutil>=2.6",
-    "tzdata>=2020.1",
     'backports.zoneinfo>=0.2.1; python_version < "3.9"',
     'time-machine>=2.6.0; implementation_name != "pypy"',
     'importlib-resources>=5.9.0; python_version < "3.9"'
@@ -50,7 +49,6 @@ python = ">=3.8"
 python-dateutil = ">=2.6"
 "backports.zoneinfo" = { version = ">=0.2.1", python = "<3.9" }
 time-machine = { version = ">=2.6.0", markers = "implementation_name != 'pypy'", optional = true }
-tzdata = ">=2020.1"
 importlib-resources = { version = ">=5.9.0", python = "<3.9" }
 
 [tool.poetry.group.test.dependencies]

--- a/src/pendulum/tz/__init__.py
+++ b/src/pendulum/tz/__init__.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import cast
-
 from pendulum.tz.local_timezone import get_local_timezone
 from pendulum.tz.local_timezone import set_local_timezone
 from pendulum.tz.local_timezone import test_local_timezone
 from pendulum.tz.timezone import UTC
 from pendulum.tz.timezone import FixedTimezone
 from pendulum.tz.timezone import Timezone
-from pendulum.utils._compat import resources
+from pendulum.utils._zoneinfo import available_timezones
 
 
 PRE_TRANSITION = "pre"
@@ -25,8 +22,7 @@ def timezones() -> tuple[str, ...]:
     global _timezones
 
     if _timezones is None:
-        with cast(Path, resources.files("tzdata").joinpath("zones")).open() as f:
-            _timezones = tuple(tz.strip() for tz in f.readlines())
+        _timezones = tuple(available_timezones())
 
     return _timezones
 


### PR DESCRIPTION
It shouldn't be necessary to have a hard dependency on tzdata. For most distributions, the tzinfo module can access the built-in timezone data. Otherwise, users can install tzdata directly.