### PR TITLE
Fix typo in variable annotation from _hour to _hours

### DIFF
--- a/src/pendulum/parsing/iso8601.py
+++ b/src/pendulum/parsing/iso8601.py
@@ -278,7 +278,7 @@ def _parse_iso8601_duration(text: str, **options: str) -> Duration | None:
     fractional = False
 
     _days: str | float
-    _hour: str | int | None
+    _hours: str | int | None
     _minutes: str | int | None
     _seconds: str | int | None
     if m.group("w"):


### PR DESCRIPTION
I've corrected a minor typo in the variable name within `parsing/iso8601.py`, changing `_hour` to `_hours` to avoid unused annotations. No related issues were found/open regarding this typo.

This update doesn't impact other parts of the codebase as confirmed by local testing and existing tests where applicable.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
