### PR TITLE
Fix test_setting_timezone_with_string and test_setting_timezone failing on a day of SDT <-> DST transition

### DIFF
--- a/tests/datetime/test_construct.py
+++ b/tests/datetime/test_construct.py
@@ -39,7 +39,7 @@ def test_creates_an_instance_default_to_utcnow():
 
 
 def test_setting_timezone():
-    tz = "Europe/London"
+    tz = "Australia/Brisbane"
     dtz = timezone(tz)
     dt = datetime.utcnow()
     offset = dtz.convert(dt).utcoffset().total_seconds() / 3600
@@ -50,7 +50,7 @@ def test_setting_timezone():
 
 
 def test_setting_timezone_with_string():
-    tz = "Europe/London"
+    tz = "Australia/Brisbane"
     dtz = timezone(tz)
     dt = datetime.utcnow()
     offset = dtz.convert(dt).utcoffset().total_seconds() / 3600


### PR DESCRIPTION
This fixes test_setting_timezone_with_string and test_setting_timezone on a day of SDT <-> DST transition by using a timezone without daylight saving time. Fixes GH #541.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
