### PR TITLE
Fix sed in release pipeline.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Hotswap build backend for Poetry
         # Maturin doesn't support building no-extension wheels, so we swap to Poetry for that
         run: |
-          sed -i '/^\[build-system\]/,/^\[/{s/^requires = .*/requires = ["poetry-core>=2.0.0,<3.0.0"]/ s/^build-backend = .*/build-backend = "poetry.core.masonry.api"/}' pyproject.toml
+          sed -i -e '/^\[build-system\]/,/^\[/{s/^requires = .*/requires = ["poetry-core>=2.0.0,<3.0.0"]/; s/^build-backend = .*/build-backend = "poetry.core.masonry.api"/}' pyproject.toml
       - name: Install dependencies
         run: poetry install --only main --only test --only typing --only build
       - name: Run poetry build


### PR DESCRIPTION
The `;` was missing between the two `s///` statements; without it it failed
with an error of `sed: -e expression #1, char 86: unknown option to `s'`

Tested with act to get _some_ sembalance of an idea if it will work, but it's
no guarantee

```
act \
  --env GITHUB_REPOSITORY=python-pendulum/pendulum \
  -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:rust-latest \
  --artifact-server-path $PWD/.artifacts \
  -W .github/workflows/release.yml \
  --matrix container:off,target:aarch64 \
  --container-architecture linux/amd64
```

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
