### PR TITLE
Remove unnecessary duplicated sdist build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           name: dist-sdist
           path: dist
 
-  build_none:
+  build_no_ext:
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -107,7 +107,7 @@ jobs:
       - name: Install dependencies
         run: poetry install --only main --only test --only typing --only build
       - name: Run poetry build
-        run: poetry build
+        run: poetry build -f wheel
       - name: Upload no-ext wheel
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Pull Request Check List

We were building sdist twice (in `build_sdist` and `build_none`). Also changed the name of the no-ext job to `build_no_ext` (previously `build_none`).

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
