### PR TITLE
[Docs] Fix typo in docs for start and end of century

### DIFF
--- a/docs/docs/modifiers.md
+++ b/docs/docs/modifiers.md
@@ -37,10 +37,10 @@ It returns the middle date between itself and the provided `DateTime` argument.
 '2019-12-31 23:59:59'
 
 >>> dt.start_of('century')
-'2000-01-01 00:00:00'
+'2001-01-01 00:00:00'
 
 >>> dt.end_of('century')
-'2099-12-31 23:59:59'
+'2100-12-31 23:59:59'
 
 >>> dt.start_of('week')
 '2012-01-30 00:00:00'


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->



### Summary
* Fix typo in docs for `dt.start_of('century')` and `dt.end_of('century')` to reflect correct century bounds
* No code change - validated the rest of the examples for modifiers ✅ 

### Validation
```bash
>>> import pendulum
>>> dt = pendulum.datetime(2012, 1, 31, 12, 0, 0)
>>> dt.start_of('century')
DateTime(2001, 1, 1, 0, 0, 0, tzinfo=Timezone('UTC'))
>>> dt.end_of('century')
DateTime(2100, 12, 31, 23, 59, 59, 999999, tzinfo=Timezone('UTC'))
```

