### PR TITLE
Fix incorrect date offset calculation in rust

### DIFF
--- a/rust/src/parsing.rs
+++ b/rust/src/parsing.rs
@@ -891,7 +891,7 @@ impl<'a> Parser<'a> {
         }
 
         for i in 1..14 {
-            if ord < MONTHS_OFFSETS[leap][i] {
+            if ord <= MONTHS_OFFSETS[leap][i] {
                 let day = ord as u32 - MONTHS_OFFSETS[leap][i - 1] as u32;
                 let month = (i - 1) as u32;
 

--- a/tests/parsing/test_parsing.py
+++ b/tests/parsing/test_parsing.py
@@ -381,6 +381,19 @@ def test_iso8601_week_number():
     assert parsed.microsecond == 0
     assert parsed.tzinfo is None
 
+    # Test case for bug #916 - 2026W36 should parse correctly
+    text = "2026W36"
+    parsed = parse(text)
+
+    assert parsed.year == 2026
+    assert parsed.month == 8
+    assert parsed.day == 31
+    assert parsed.hour == 0
+    assert parsed.minute == 0
+    assert parsed.second == 0
+    assert parsed.microsecond == 0
+    assert parsed.tzinfo is None
+
 
 def test_iso8601_week_number_with_time():
     text = "2012-W05T09"


### PR DESCRIPTION
## Description

Fixes #916

I dug into the rust parsing code a bit and saw that the ordinal calculation might be why 2026W36 was getting the error `ValueError: day is out of range for month`. 2026W36 should be August 31, 2026, which becomes ordinal day 243. 

Looking at the `MONTHS_OFFSETS` for non-leap year (2026):
[0]==-1, [1]==0, [2]==31, [3]==59, [4]==90, [5]==120, [6]==151, [7]==181, [8]==212, [9]==243, [10]==273, [11]==304, [12]==334, [13]==365

The original loop: `for i in 1..14`:
- i=1: ord < MONTHS_OFFSETS[0][1] → 243 < 0? No
- i=2: ord < MONTHS_OFFSETS[0][2] → 243 < 31? No
- ...
- i=8: ord < MONTHS_OFFSETS[0][8] → 243 < 212? No
- i=9: ord < MONTHS_OFFSETS[0][9] → 243 < 243? No ← This is the problem!

Since 243 < 243 is false, it continues to:
- i=10: ord < MONTHS_OFFSETS[0][10] → 243 < 273? Yes

At this point, the original code would execute:
```rust
let day = ord as u32 - MONTHS_OFFSETS[leap][i - 1] as u32;  // i=10, so i-1=9
let month = (i - 1) as u32;  // month = 9 (September, 1-based)
```

So: day = 243 - MONTHS_OFFSETS[0][9] = 243 - 243 = 0

This gives us month=9, day=0, which is September 0th - an invalid date, hence the "day is out of range for month" error.

Changing the comparison to be `<=` means that September (9) is matched appropriately as the month offset, so when it becomes 1-based with `let month = (i - 1) as u32;`, it becomes August once more.

I added a new test case for this as well in order to verify the functionality! I'm no rust expert though so this may be completely off base :sweat_smile:

Shoutout to @d3jawu for helping walk me through some of the rust pieces :blush:

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
