### PR TITLE
docs: fix incorrect example outputs in addition_subtraction.md

### DIFF
--- a/docs/docs/addition_subtraction.md
+++ b/docs/docs/addition_subtraction.md
@@ -51,9 +51,9 @@ Each method returns a new `DateTime` instance.
 >>> dt = dt.add(hours=24)
 '2012-01-29 00:00:00'
 >>> dt = dt.add(hours=1)
-'2012-02-25 01:00:00'
+'2012-01-29 01:00:00'
 >>> dt = dt.subtract(hours=1)
-'2012-02-29 00:00:00'
+'2012-01-29 00:00:00'
 >>> dt = dt.subtract(hours=24)
 '2012-01-28 00:00:00'
 
@@ -64,7 +64,7 @@ Each method returns a new `DateTime` instance.
 >>> dt = dt.subtract(minutes=1)
 '2012-01-28 01:01:00'
 >>> dt = dt.subtract(minutes=24)
-'2012-01-28 00:00:00'
+'2012-01-28 00:37:00'
 
 >>> dt = dt.add(seconds=61)
 '2012-01-28 00:01:01'


### PR DESCRIPTION
## Summary

Three example output values in the addition/subtraction documentation are incorrect.

## Errors fixed

The example simulates a chain of operations starting from `pendulum.datetime(2012, 1, 28)`:

1. After `dt.add(hours=24)` → `2012-01-29 00:00:00` (correct)
2. After `dt.add(hours=1)` → doc shows `'2012-02-25 01:00:00'`, **should be `'2012-01-29 01:00:00'`**
3. After `dt.subtract(hours=1)` → doc shows `'2012-02-29 00:00:00'`, **should be `'2012-01-29 00:00:00'`** (also Feb 29 doesn't exist in 2012, which is a leap year, making this doubly wrong)
4. After several minute operations reaching `01:01:00`, `dt.subtract(minutes=24)` → doc shows `'2012-01-28 00:00:00'`, **should be `'2012-01-28 00:37:00'`** (01:01 minus 24 minutes = 00:37)

Verified with plain Python `datetime` arithmetic.

Closes #925