### PR TITLE
Add parsing helper functions for DateTime, Date, Time, and Duration

### DIFF
--- a/docs/docs/parsing.md
+++ b/docs/docs/parsing.md
@@ -7,7 +7,7 @@ The library natively supports the RFC 3339 format, most ISO 8601 formats and som
 
 >>> dt = pendulum.parse('1975-05-21T22:00:00')
 >>> print(dt)
-'1975-05-21T22:00:00+00:00
+'1975-05-21T22:00:00+00:00'
 
 # You can pass a tz keyword to specify the timezone
 >>> dt = pendulum.parse('1975-05-21T22:00:00', tz='Europe/Paris')
@@ -112,3 +112,21 @@ When passing only time information the date will default to today.
     >>> pendulum.parse('12:04:23', exact=True)
     Time(12, 04, 23)
     ```
+### Strict parsing helpers
+
+Pendulum also provides helper functions for strict parsing of specific types:
+
+```python
+>>> import pendulum
+
+>>> pendulum.parse_datetime("2016-10-16T12:34:56")
+DateTime(...)
+
+>>> pendulum.parse_date("2016-10-16")
+Date(2016, 10, 16)
+
+>>> pendulum.parse_time("12:34:56")
+Time(12, 34, 56)
+
+>>> pendulum.parse_duration("PT2H")
+Duration(...)

--- a/src/pendulum/__init__.py
+++ b/src/pendulum/__init__.py
@@ -31,6 +31,10 @@ from pendulum.helpers import week_ends_at
 from pendulum.helpers import week_starts_at
 from pendulum.interval import Interval
 from pendulum.parser import parse as parse
+from pendulum.parser import parse_datetime as parse_datetime
+from pendulum.parser import parse_time as parse_time
+from pendulum.parser import parse_date as parse_date
+from pendulum.parser import parse_duration as parse_duration
 from pendulum.time import Time
 from pendulum.tz import UTC
 from pendulum.tz import fixed_timezone

--- a/src/pendulum/__init__.py
+++ b/src/pendulum/__init__.py
@@ -31,10 +31,10 @@ from pendulum.helpers import week_ends_at
 from pendulum.helpers import week_starts_at
 from pendulum.interval import Interval
 from pendulum.parser import parse as parse
-from pendulum.parser import parse_datetime as parse_datetime
-from pendulum.parser import parse_time as parse_time
 from pendulum.parser import parse_date as parse_date
+from pendulum.parser import parse_datetime as parse_datetime
 from pendulum.parser import parse_duration as parse_duration
+from pendulum.parser import parse_time as parse_time
 from pendulum.time import Time
 from pendulum.tz import UTC
 from pendulum.tz import fixed_timezone

--- a/src/pendulum/formatting/formatter.py
+++ b/src/pendulum/formatting/formatter.py
@@ -255,11 +255,13 @@ class Formatter:
         loaded_locale: Locale = Locale.load(locale or pendulum.get_locale())
 
         result = self._FORMAT_RE.sub(
-            lambda m: m.group(1)
-            if m.group(1)
-            else m.group(2)
-            if m.group(2)
-            else self._format_token(dt, m.group(3), loaded_locale),
+            lambda m: (
+                m.group(1)
+                if m.group(1)
+                else m.group(2)
+                if m.group(2)
+                else self._format_token(dt, m.group(3), loaded_locale)
+            ),
             fmt,
         )
 

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -158,3 +158,15 @@ def parse_date(text: str, **options: t.Any) -> Date:
     if not isinstance(result, Date):
         raise ValueError(f"Invalid date string: {text}")
     return result
+
+
+def parse_time(text: str, **options: t.Any) -> Time:
+    """
+    Parses a string into a Time.
+
+    :param text: The string to parse.
+    """
+    result = parse(text, **options)
+    if not isinstance(result, Time):
+        raise ValueError(f"Invalid time string: {text}")
+    return result

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -146,14 +146,9 @@ def parse_datetime(text: str, **options: t.Any) -> DateTime:
 
     :param text: The string to parse.
     """
-    if "T" not in text and " " not in text:
-        raise ValueError(f"Invalid datetime string: {text}")
-
     parsed = parse(text, **options)
-
     if not isinstance(parsed, DateTime):
         raise ValueError(f"Invalid datetime string: {text}")
-
     return parsed
 
 
@@ -163,15 +158,11 @@ def parse_date(text: str, **options: t.Any) -> Date:
 
     :param text: The string to parse.
     """
-    if "T" in text or ":" in text:
-        raise ValueError(f"Invalid date string: {text}")
-
-    parsed = parse(text, **options)
+    parsed = parse(text, exact = True, **options)
     if not isinstance(parsed, Date):
         if isinstance(parsed, DateTime):
             return parsed.date()
         raise ValueError(f"Invalid date string: {text}")
-
     return parsed
 
 
@@ -181,9 +172,7 @@ def parse_time(text: str, **options: t.Any) -> Time:
 
     :param text: The string to parse.
     """
-    if ":" not in text or "-" in text:
-        raise ValueError(f"Invalid time string: {text}")
-    parsed = parse(text, **options)
+    parsed = parse(text, exact = True, **options)
     if not isinstance(parsed, Time):
         if isinstance(parsed, DateTime):
             return parsed.time()

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -7,6 +7,9 @@ import typing as t
 import pendulum
 
 from pendulum._pendulum import is_leap
+from pendulum.datetime import DateTime
+from pendulum.date import Date
+from pendulum.time import Time
 from pendulum.duration import Duration
 from pendulum.parsing import _Interval
 from pendulum.parsing import parse as base_parse

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -6,21 +6,17 @@ import typing as t
 
 import pendulum
 
-from pendulum._pendulum import is_leap
-from pendulum.datetime import DateTime
 from pendulum.date import Date
-from pendulum.time import Time
+from pendulum.datetime import DateTime
 from pendulum.duration import Duration
 from pendulum.parsing import _Interval
 from pendulum.parsing import parse as base_parse
+from pendulum.time import Time
 from pendulum.tz.timezone import UTC
 
 
 if t.TYPE_CHECKING:
-    from pendulum.date import Date
-    from pendulum.datetime import DateTime
     from pendulum.interval import Interval
-    from pendulum.time import Time
 
 with_extensions = os.getenv("PENDULUM_EXTENSIONS", "1") == "1"
 

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -154,7 +154,7 @@ def parse_date(text: str, **options: t.Any) -> Date:
 
     :param text: The string to parse.
     """
-    parsed = parse(text, exact = True, **options)
+    parsed = parse(text, exact=True, **options)
     if not isinstance(parsed, Date):
         if isinstance(parsed, DateTime):
             return parsed.date()
@@ -168,7 +168,7 @@ def parse_time(text: str, **options: t.Any) -> Time:
 
     :param text: The string to parse.
     """
-    parsed = parse(text, exact = True, **options)
+    parsed = parse(text, exact=True, **options)
     if not isinstance(parsed, Time):
         if isinstance(parsed, DateTime):
             return parsed.time()

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -143,10 +143,10 @@ def parse_datetime(text: str, **options: t.Any) -> DateTime:
 
     :param text: The string to parse.
     """
-    result = parse(text, **options)
-    if not isinstance(result, DateTime):
+    parsed = parse(text, **options)
+    if not isinstance(parsed, DateTime):
         raise ValueError(f"Invalid datetime string: {text}")
-    return result
+    return parsed
 
 
 def parse_date(text: str, **options: t.Any) -> Date:
@@ -155,10 +155,10 @@ def parse_date(text: str, **options: t.Any) -> Date:
 
     :param text: The string to parse.
     """
-    result = parse(text, **options)
-    if not isinstance(result, Date):
+    parsed = parse(text, **options)
+    if not isinstance(parsed, Date):
         raise ValueError(f"Invalid date string: {text}")
-    return result
+    return parsed
 
 
 def parse_time(text: str, **options: t.Any) -> Time:
@@ -167,10 +167,10 @@ def parse_time(text: str, **options: t.Any) -> Time:
 
     :param text: The string to parse.
     """
-    result = parse(text, **options)
-    if not isinstance(result, Time):
+    parsed = parse(text, **options)
+    if not isinstance(parsed, Time):
         raise ValueError(f"Invalid time string: {text}")
-    return result
+    return parsed
 
 
 def parse_duration(text: str, **options: t.Any) -> Duration:
@@ -179,7 +179,7 @@ def parse_duration(text: str, **options: t.Any) -> Duration:
 
     :param text: The string to parse.
     """
-    result = parse(text, **options)
-    if not isinstance(result, Duration):
+    parsed = parse(text, **options)
+    if not isinstance(parsed, Duration):
         raise ValueError(f"Invalid duration string: {text}")
-    return result
+    return parsed

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -134,3 +134,15 @@ def _parse(
         )
 
     raise NotImplementedError
+
+
+def parse_datetime(text: str, **options: t.Any) -> DateTime:
+    """
+    Parses a string into a DateTime.
+
+    :param text: The string to parse.
+    """
+    result = parse(text, **options)
+    if not isinstance(result, DateTime):
+        raise ValueError(f"Invalid datetime string: {text}")
+    return result

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -146,9 +146,14 @@ def parse_datetime(text: str, **options: t.Any) -> DateTime:
 
     :param text: The string to parse.
     """
+    if "T" not in text and " " not in text:
+        raise ValueError(f"Invalid datetime string: {text}")
+
     parsed = parse(text, **options)
+
     if not isinstance(parsed, DateTime):
         raise ValueError(f"Invalid datetime string: {text}")
+
     return parsed
 
 
@@ -158,9 +163,15 @@ def parse_date(text: str, **options: t.Any) -> Date:
 
     :param text: The string to parse.
     """
+    if "T" in text or ":" in text:
+        raise ValueError(f"Invalid date string: {text}")
+
     parsed = parse(text, **options)
     if not isinstance(parsed, Date):
+        if isinstance(parsed, DateTime):
+            return parsed.date()
         raise ValueError(f"Invalid date string: {text}")
+
     return parsed
 
 
@@ -170,8 +181,12 @@ def parse_time(text: str, **options: t.Any) -> Time:
 
     :param text: The string to parse.
     """
+    if ":" not in text or "-" in text:
+        raise ValueError(f"Invalid time string: {text}")
     parsed = parse(text, **options)
     if not isinstance(parsed, Time):
+        if isinstance(parsed, DateTime):
+            return parsed.time()
         raise ValueError(f"Invalid time string: {text}")
     return parsed
 

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -146,3 +146,15 @@ def parse_datetime(text: str, **options: t.Any) -> DateTime:
     if not isinstance(result, DateTime):
         raise ValueError(f"Invalid datetime string: {text}")
     return result
+
+
+def parse_date(text: str, **options: t.Any) -> Date:
+    """
+    Parses a string into a Date.
+
+    :param text: The string to parse.
+    """
+    result = parse(text, **options)
+    if not isinstance(result, Date):
+        raise ValueError(f"Invalid date string: {text}")
+    return result

--- a/src/pendulum/parser.py
+++ b/src/pendulum/parser.py
@@ -6,6 +6,7 @@ import typing as t
 
 import pendulum
 
+from pendulum._pendulum import is_leap
 from pendulum.duration import Duration
 from pendulum.parsing import _Interval
 from pendulum.parsing import parse as base_parse
@@ -169,4 +170,16 @@ def parse_time(text: str, **options: t.Any) -> Time:
     result = parse(text, **options)
     if not isinstance(result, Time):
         raise ValueError(f"Invalid time string: {text}")
+    return result
+
+
+def parse_duration(text: str, **options: t.Any) -> Duration:
+    """
+    Parses a string into a Duration.
+
+    :param text: The string to parse.
+    """
+    result = parse(text, **options)
+    if not isinstance(result, Duration):
+        raise ValueError(f"Invalid duration string: {text}")
     return result

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -7,6 +7,8 @@ from pendulum.parser import (
     parse_duration,
 )
 
+# tests for parse_datetime
+
 def test_parse_datetime_valid() -> None:
     dt = parse_datetime("2026-03-19T11:28:37")
     assert dt.year == 2026
@@ -18,3 +20,13 @@ def test_parse_datetime_rejects_date() -> None:
 def test_parse_datetime_rejects_interval() -> None:
     with pytest.raises(ValueError):
         dt = parse_datetime("2026-03-19T12:00:00/2026-03-19T13:00:00")
+
+# tests for parse_date
+
+def test_parse_date_valid() -> None:
+    dt = parse_date("2026-03-19")
+    assert dt.year == 2026
+
+def test_parse_date_rejects_datetime() -> None:
+    with pytest.raises(ValueError):
+        dt = parse_date("2026-03-19T11:28:37")

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -40,3 +40,13 @@ def test_parse_time_valid() -> None:
 def test_parse_time_rejects_datetime() -> None:
     with pytest.raises(ValueError):
         parse_time("2026-03-19T11:28:37")
+
+# tests for parse_duration
+
+def test_parse_duration_valid() -> None:
+    dur = parse_duration("PT2H")
+    assert dur.hours == 2
+
+def test_parse_duration_rejects_datetime() -> None:
+    with pytest.raises(ValueError):
+        parse_duration("2026-03-19T11:28:37")

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -42,6 +42,10 @@ def test_parse_date_accepts_datetime() -> None:
     d = parse_date("2026-03-19T11:28:37")
     assert d.day == 19
 
+def test_parse_date_rejects_time() -> None:
+    with pytest.raises(ValueError):
+        parse_date("11:28:37")
+
 
 # tests for parse_time
 
@@ -55,6 +59,9 @@ def test_parse_time_accepts_datetime() -> None:
     t = parse_time("2026-03-19T11:28:37")
     assert t.minute  == 28
 
+def test_parse_time_rejects_date() -> None:
+    with pytest.raises(ValueError):
+        parse_time("2026-03-19")
 
 # tests for parse_duration
 

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -15,18 +15,28 @@ def test_parse_datetime_valid() -> None:
 
 def test_parse_datetime_rejects_date() -> None:
     with pytest.raises(ValueError):
-        dt = parse_datetime("2026-03-19")
+        parse_datetime("2026-03-19")
 
 def test_parse_datetime_rejects_interval() -> None:
     with pytest.raises(ValueError):
-        dt = parse_datetime("2026-03-19T12:00:00/2026-03-19T13:00:00")
+        parse_datetime("2026-03-19T12:00:00/2026-03-19T13:00:00")
 
 # tests for parse_date
 
 def test_parse_date_valid() -> None:
-    dt = parse_date("2026-03-19")
-    assert dt.year == 2026
+    d = parse_date("2026-03-19")
+    assert d.day == 19
 
 def test_parse_date_rejects_datetime() -> None:
     with pytest.raises(ValueError):
-        dt = parse_date("2026-03-19T11:28:37")
+        parse_date("2026-03-19T11:28:37")
+
+# tests for parse_time
+
+def test_parse_time_valid() -> None:
+    t = parse_time("11:28:37")
+    assert t.hour == 11
+
+def test_parse_time_rejects_datetime() -> None:
+    with pytest.raises(ValueError):
+        parse_time("2026-03-19T11:28:37")

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -19,9 +19,11 @@ def test_parse_datetime_accepts_date() -> None:
     dt = parse_datetime("2026-03-19")
     assert dt.hour == 0
 
+
 def test_parse_datetime_rejects_duration() -> None:
     with pytest.raises(ValueError):
         parse_datetime("PT2H")
+
 
 def test_parse_datetime_rejects_interval() -> None:
     with pytest.raises(ValueError):
@@ -45,13 +47,16 @@ def test_parse_date_accepts_datetime() -> None:
     d = parse_date("2026-03-19T11:28:37")
     assert d.day == 19
 
+
 def test_parse_date_rejects_time() -> None:
     with pytest.raises(ValueError):
         parse_date("11:28:37")
 
+
 def test_parse_date_rejects_duration() -> None:
     with pytest.raises(ValueError):
         parse_date("PT2H")
+
 
 def test_parse_date_rejects_intervals() -> None:
     with pytest.raises(ValueError):
@@ -68,19 +73,23 @@ def test_parse_time_valid() -> None:
 
 def test_parse_time_accepts_datetime() -> None:
     t = parse_time("2026-03-19T11:28:37")
-    assert t.minute  == 28
+    assert t.minute == 28
+
 
 def test_parse_time_rejects_date() -> None:
     with pytest.raises(ValueError):
         parse_time("2026-03-19")
 
+
 def test_parse_time_rejects_duration() -> None:
     with pytest.raises(ValueError):
         parse_time("PT2H")
 
+
 def test_parse_time_rejects_interval() -> None:
     with pytest.raises(ValueError):
         parse_time("2026-03-19T12:00:00/2026-03-19T13:00:00")
+
 
 # tests for parse_duration
 

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -19,6 +19,9 @@ def test_parse_datetime_accepts_date() -> None:
     dt = parse_datetime("2026-03-19")
     assert dt.hour == 0
 
+def test_parse_datetime_rejects_duration() -> None:
+    with pytest.raises(ValueError):
+        parse_datetime("PT2H")
 
 def test_parse_datetime_rejects_interval() -> None:
     with pytest.raises(ValueError):
@@ -46,6 +49,14 @@ def test_parse_date_rejects_time() -> None:
     with pytest.raises(ValueError):
         parse_date("11:28:37")
 
+def test_parse_date_rejects_duration() -> None:
+    with pytest.raises(ValueError):
+        parse_date("PT2H")
+
+def test_parse_date_rejects_intervals() -> None:
+    with pytest.raises(ValueError):
+        parse_date("2026-03-19T12:00:00/2026-03-19T13:00:00")
+
 
 # tests for parse_time
 
@@ -62,6 +73,14 @@ def test_parse_time_accepts_datetime() -> None:
 def test_parse_time_rejects_date() -> None:
     with pytest.raises(ValueError):
         parse_time("2026-03-19")
+
+def test_parse_time_rejects_duration() -> None:
+    with pytest.raises(ValueError):
+        parse_time("PT2H")
+
+def test_parse_time_rejects_interval() -> None:
+    with pytest.raises(ValueError):
+        parse_time("2026-03-19T12:00:00/2026-03-19T13:00:00")
 
 # tests for parse_duration
 

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -9,47 +9,60 @@ from pendulum.parser import (
 
 # tests for parse_datetime
 
+
 def test_parse_datetime_valid() -> None:
     dt = parse_datetime("2026-03-19T11:28:37")
     assert dt.year == 2026
 
-def test_parse_datetime_rejects_date() -> None:
-    with pytest.raises(ValueError):
-        parse_datetime("2026-03-19")
+
+def test_parse_datetime_accepts_date() -> None:
+    dt = parse_datetime("2026-03-19")
+    assert dt.hour == 0
+
 
 def test_parse_datetime_rejects_interval() -> None:
     with pytest.raises(ValueError):
         parse_datetime("2026-03-19T12:00:00/2026-03-19T13:00:00")
 
+
 def test_parse_datetime_accepts_only_year() -> None:
     dt = parse_datetime("2026")
     assert dt.year == 2026
 
+
 # tests for parse_date
+
 
 def test_parse_date_valid() -> None:
     d = parse_date("2026-03-19")
     assert d.day == 19
 
+
 def test_parse_date_rejects_datetime() -> None:
     with pytest.raises(ValueError):
         parse_date("2026-03-19T11:28:37")
 
+
 # tests for parse_time
+
 
 def test_parse_time_valid() -> None:
     t = parse_time("11:28:37")
     assert t.hour == 11
 
+
 def test_parse_time_rejects_datetime() -> None:
     with pytest.raises(ValueError):
         parse_time("2026-03-19T11:28:37")
 
+
 # tests for parse_duration
+
 
 def test_parse_duration_valid() -> None:
     dur = parse_duration("PT2H")
     assert dur.hours == 2
+
 
 def test_parse_duration_rejects_datetime() -> None:
     with pytest.raises(ValueError):

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -38,7 +38,7 @@ def test_parse_date_valid() -> None:
     assert d.day == 19
 
 
-def test_parse_date_rejects_datetime() -> None:
+def test_parse_date_accepts_datetime() -> None:
     with pytest.raises(ValueError):
         parse_date("2026-03-19T11:28:37")
 
@@ -51,7 +51,7 @@ def test_parse_time_valid() -> None:
     assert t.hour == 11
 
 
-def test_parse_time_rejects_datetime() -> None:
+def test_parse_time_accepts_datetime() -> None:
     with pytest.raises(ValueError):
         parse_time("2026-03-19T11:28:37")
 

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -21,6 +21,10 @@ def test_parse_datetime_rejects_interval() -> None:
     with pytest.raises(ValueError):
         parse_datetime("2026-03-19T12:00:00/2026-03-19T13:00:00")
 
+def test_parse_datetime_accepts_only_year() -> None:
+    dt = parse_datetime("2026")
+    assert dt.year == 2026
+
 # tests for parse_date
 
 def test_parse_date_valid() -> None:

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pendulum.parser import (
+    parse_datetime,
+    parse_date,
+    parse_time,
+    parse_duration,
+)
+
+def test_parse_datetime_valid() -> None:
+    dt = parse_datetime("2026-03-19T11:28:37")
+    assert dt.year == 2026
+
+def test_parse_datetime_rejects_date() -> None:
+    with pytest.raises(ValueError):
+        dt = parse_datetime("2026-03-19")
+
+def test_parse_datetime_rejects_interval() -> None:
+    with pytest.raises(ValueError):
+        dt = parse_datetime("2026-03-19T12:00:00/2026-03-19T13:00:00")

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import pytest
 
-from pendulum.parser import (
-    parse_datetime,
-    parse_date,
-    parse_time,
-    parse_duration,
-)
+from pendulum.parser import parse_date
+from pendulum.parser import parse_datetime
+from pendulum.parser import parse_duration
+from pendulum.parser import parse_time
+
 
 # tests for parse_datetime
 

--- a/tests/parsing/test_strict_parse.py
+++ b/tests/parsing/test_strict_parse.py
@@ -39,8 +39,8 @@ def test_parse_date_valid() -> None:
 
 
 def test_parse_date_accepts_datetime() -> None:
-    with pytest.raises(ValueError):
-        parse_date("2026-03-19T11:28:37")
+    d = parse_date("2026-03-19T11:28:37")
+    assert d.day == 19
 
 
 # tests for parse_time
@@ -52,8 +52,8 @@ def test_parse_time_valid() -> None:
 
 
 def test_parse_time_accepts_datetime() -> None:
-    with pytest.raises(ValueError):
-        parse_time("2026-03-19T11:28:37")
+    t = parse_time("2026-03-19T11:28:37")
+    assert t.minute  == 28
 
 
 # tests for parse_duration


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
This PR adds parsing helper functions:

- `parse_datetime`
- `parse_date`
- `parse_time`
- `parse_duration`


These functions provide a convenient to parse string without having to use `assert isinstance(..., Time)` etc. everytime while parsing in type checked codebases.
Closes #917 