### PR TITLE
fix: precise_diff inconsistent with pendulum.DateTime subclasses (#906)

### DIFF
--- a/rust/src/python/helpers.rs
+++ b/rust/src/python/helpers.rs
@@ -184,7 +184,7 @@ pub fn precise_diff<'py>(
         total_seconds: 0,
         tz: dt2_tz.as_str(),
         offset: get_offset(dt2)?,
-        is_datetime: PyDateTime::is_exact_type_of(dt2),
+        is_datetime: PyDateTime::is_type_of(dt2),
     };
     let in_same_tz: bool = dtinfo1.tz == dtinfo2.tz && !dtinfo1.tz.is_empty();
     let mut total_days = helpers::day_number(dtinfo2.year, dtinfo2.month as u8, dtinfo2.day as u8)

--- a/tests/interval/test_construct.py
+++ b/tests/interval/test_construct.py
@@ -18,6 +18,29 @@ def test_with_datetimes():
     assert_datetime(p.end, 2000, 1, 31)
 
 
+def test_native_datetime_interval_consistency():
+    """Native datetime inputs should produce the same results as pendulum datetimes.
+
+    Regression test for https://github.com/python-pendulum/pendulum/issues/906
+    """
+    # With pendulum datetimes
+    start_p = pendulum.datetime(2025, 7, 25, 19, 26, 34)
+    end_p = pendulum.datetime(2025, 7, 29, 19, 26, 34)
+    interval_p = pendulum.interval(start_p, end_p)
+
+    # With native datetimes
+    start_n = datetime(2025, 7, 25, 19, 26, 34)
+    end_n = datetime(2025, 7, 29, 19, 26, 34)
+    interval_n = pendulum.interval(start_n, end_n)
+
+    # Both should produce identical results
+    assert interval_p.in_words() == interval_n.in_words()
+    assert interval_p.in_words() == "4 days"
+    assert interval_p.days == interval_n.days == 4
+    assert interval_p.hours == interval_n.hours == 0
+    assert interval_p.minutes == interval_n.minutes == 0
+
+
 def test_with_pendulum():
     dt1 = pendulum.DateTime(2000, 1, 1)
     dt2 = pendulum.DateTime(2000, 1, 31)


### PR DESCRIPTION
## Problem

When `pendulum.interval()` is called with native `datetime.datetime` objects, the resulting interval produces incorrect values for `in_words()`, `hours`, `minutes`, etc. This is because `Interval.__init__` converts native datetimes to `pendulum.DateTime`, but the underlying Rust `precise_diff` function handles them inconsistently.

**Example:**
```python
from datetime import datetime
import pendulum

start = datetime(2025, 7, 25, 19, 26, 34)
end = datetime(2025, 7, 29, 19, 26, 34)
interval = pendulum.interval(start, end)

# Before fix:
interval.in_words()   # "3 days 4 hours 33 minutes" (WRONG)
interval.hours        # 4 (WRONG)

# After fix:
interval.in_words()   # "4 days" (CORRECT)
interval.hours        # 0 (CORRECT)
```

## Root Cause

In `rust/src/python/helpers.rs`, the `precise_diff` function uses inconsistent type checks:
- Line 174: `is_datetime: PyDateTime::is_type_of(dt1)` — returns `True` for `pendulum.DateTime` (subclass)
- Line 187: `is_datetime: PyDateTime::is_exact_type_of(dt2)` — returns `False` for `pendulum.DateTime`

When `dt2.is_datetime` is `False`, its hour/minute/second components are left at 0, producing an incorrect diff.

## Fix

Changed line 187 from `is_exact_type_of` to `is_type_of` to match line 174.

## Testing

- Added regression test `test_native_datetime_interval_consistency` that verifies native and pendulum datetime inputs produce identical results
- All 42 existing interval tests pass

Fixes #906