### PR TITLE
fix: pendulum.parse('2007-12-13/14:30') raised TypeError instead of uniform ValueError

### DIFF
--- a/src/pendulum/interval.py
+++ b/src/pendulum/interval.py
@@ -39,8 +39,9 @@ class Interval(Duration, Generic[_T]):
     """
 
     def __new__(cls, start: _T, end: _T, absolute: bool = False) -> Self:
-        if (isinstance(start, datetime) and not isinstance(end, datetime)) or (
-            not isinstance(start, datetime) and isinstance(end, datetime)
+        if (isinstance(start, datetime) and not isinstance(end, datetime) or
+            not isinstance(start, datetime) and isinstance(end, datetime) or
+            not (isinstance(start, date) and isinstance(end, date))  # Time not allowed
         ):
             raise ValueError(
                 "Both start and end of an Interval must have the same type"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import pendulum
 
 from tests.conftest import assert_date
@@ -125,6 +127,19 @@ def test_parse_interval() -> None:
     assert interval.start.offset == 0
     assert_datetime(interval.end, 2008, 5, 11, 15, 30, 0, 0)
     assert interval.end.offset == 0
+
+
+def test_parse_interval_mixed_types():
+    error = 'Both start and end of an Interval must have the same type'
+
+    # date / time is not allowed in ISO 8601
+    with pytest.raises(ValueError, match=error):
+        pendulum.parse('2007-12-13/14:30')
+
+    # datetime / time is allowed in some lenient ISO 8601 implementations (e.g. aniso8601 package).
+    # Not allowed in pendulum for strictness and consistency.
+    with pytest.raises(ValueError, match=error):
+        pendulum.parse('2007-12-13T14:30/15:45')
 
 
 def test_parse_now() -> None:


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code - not applicable

When trying to parse non-standard Interval format mixing date/datetime and time (both individually valid), error message is inconsistent because `Time` is falling through unchecked.

Behavior in 3.2.0:

    >>> pendulum.parse('2007-12-13/14:30')
    Traceback (most recent call last):
      File "<python-input-177>", line 1, in <module>
        pendulum.parse('2007-12-13/14:30')
        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
      File "<..>/python3.14/site-packages/pendulum/parser.py", line 36, in parse
        return _parse(text, **options)
      File "<..>/python3.14/site-packages/pendulum/parser.py", line 112, in _parse
        return pendulum.interval(
               ~~~~~~~~~~~~~~~~~^
            pendulum.instance(
            ^^^^^^^^^^^^^^^^^^
        ...<4 lines>...
            ),
            ^^
        )
        ^
      File "<..>/python3.14/site-packages/pendulum/__init__.py", line 335, in interval
        return Interval(start, end, absolute=absolute)
      File "<..>/python3.14/site-packages/pendulum/interval.py", line 115, in __new__
        delta: timedelta = _end - _start
                           ~~~~~^~~~~~~~
    TypeError: unsupported operand type(s) for -: 'Time' and 'datetime.date'

    >>> pendulum.parse('2007-12-13T14:30/15:45')
    Traceback (most recent call last):
      File "<python-input-178>", line 1, in <module>
        pendulum.parse('2007-12-13T14:30/15:45')
        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "<..>/python3.14/site-packages/pendulum/parser.py", line 36, in parse
        return _parse(text, **options)
      File "<..>/python3.14/site-packages/pendulum/parser.py", line 112, in _parse
        return pendulum.interval(
               ~~~~~~~~~~~~~~~~~^
            pendulum.instance(
            ^^^^^^^^^^^^^^^^^^
        ...<4 lines>...
            ),
            ^^
        )
        ^
      File "<..>/python3.14/site-packages/pendulum/__init__.py", line 335, in interval
        return Interval(start, end, absolute=absolute)
      File "<..>/python3.14/site-packages/pendulum/interval.py", line 45, in __new__
        raise ValueError(
            "Both start and end of an Interval must have the same type"
        )
    ValueError: Both start and end of an Interval must have the same type


After fix the exception is uniform in all cases:

    >>> pendulum.parse('2007-12-13/14:30')
    Traceback (most recent call last):
      File "<python-input-1>", line 1, in <module>
        pendulum.parse('2007-12-13/14:30')
        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
      File "<..>/python3.14/site-packages/pendulum/parser.py", line 36, in parse
        return _parse(text, **options)
      File "<..>/python3.14/site-packages/pendulum/parser.py", line 112, in _parse
        return pendulum.interval(
               ~~~~~~~~~~~~~~~~~^
            pendulum.instance(
            ^^^^^^^^^^^^^^^^^^
        ...<4 lines>...
            ),
            ^^
        )
        ^
      File "<..>/python3.14/site-packages/pendulum/__init__.py", line 334, in interval
        return Interval(start, end, absolute=absolute)
      File "<..>/python3.14/site-packages/pendulum/interval.py", line 46, in __new__
        raise ValueError(
            "Both start and end of an Interval must have the same type"
        )
    ValueError: Both start and end of an Interval must have the same type

Note: format `2007-12-13T14:30/15:45` is allowed in some lenient ISO 8601 implementations (e.g. [aniso8601](https://pypi.org/project/aniso8601/) package). I believe it's a good thing that pendulum does not allow it because it's ambiguous.


