### PR TITLE
Fix from_timestamp for negative timestamps before epoch

### DIFF
--- a/src/pendulum/__init__.py
+++ b/src/pendulum/__init__.py
@@ -288,11 +288,7 @@ def from_timestamp(timestamp: int | float, tz: str | Timezone = UTC) -> DateTime
     """
     try:
         dt = _datetime.datetime.fromtimestamp(timestamp, tz=UTC)
-    except OSError:
-        # On some platforms (notably Windows), datetime.fromtimestamp
-        # raises OSError for negative timestamps that are too far from
-        # the Unix epoch.  Fall back to computing the result from the
-        # epoch and applying the offset manually.
+    except (OSError, OverflowError):
         epoch = _datetime.datetime(1970, 1, 1, tzinfo=UTC)
         dt = epoch + _datetime.timedelta(seconds=timestamp)
 

--- a/src/pendulum/__init__.py
+++ b/src/pendulum/__init__.py
@@ -286,7 +286,15 @@ def from_timestamp(timestamp: int | float, tz: str | Timezone = UTC) -> DateTime
     """
     Create a DateTime instance from a timestamp.
     """
-    dt = _datetime.datetime.fromtimestamp(timestamp, tz=UTC)
+    try:
+        dt = _datetime.datetime.fromtimestamp(timestamp, tz=UTC)
+    except OSError:
+        # On some platforms (notably Windows), datetime.fromtimestamp
+        # raises OSError for negative timestamps that are too far from
+        # the Unix epoch.  Fall back to computing the result from the
+        # epoch and applying the offset manually.
+        epoch = _datetime.datetime(1970, 1, 1, tzinfo=UTC)
+        dt = epoch + _datetime.timedelta(seconds=timestamp)
 
     dt = datetime(
         dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond

--- a/src/pendulum/datetime.py
+++ b/src/pendulum/datetime.py
@@ -1253,11 +1253,21 @@ class DateTime(datetime.datetime, Date):
     def fromtimestamp(cls, t: float, tz: datetime.tzinfo | None = None) -> Self:
         tzinfo = pendulum._safe_timezone(tz)
 
-        return cls.instance(datetime.datetime.fromtimestamp(t, tz=tzinfo), tz=tzinfo)
+        try:
+            dt = datetime.datetime.fromtimestamp(t, tz=tzinfo)
+        except OSError:
+            dt = (cls._EPOCH + datetime.timedelta(seconds=t)).astimezone(tzinfo)
+
+        return cls.instance(dt, tz=tzinfo)
 
     @classmethod
     def utcfromtimestamp(cls, t: float) -> Self:
-        return cls.instance(datetime.datetime.utcfromtimestamp(t), tz=None)
+        try:
+            dt = datetime.datetime.utcfromtimestamp(t)
+        except OSError:
+            dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=t)
+
+        return cls.instance(dt, tz=None)
 
     @classmethod
     def fromordinal(cls, n: int) -> Self:

--- a/src/pendulum/datetime.py
+++ b/src/pendulum/datetime.py
@@ -1255,7 +1255,7 @@ class DateTime(datetime.datetime, Date):
 
         try:
             dt = datetime.datetime.fromtimestamp(t, tz=tzinfo)
-        except OSError:
+        except (OSError, OverflowError):
             dt = (cls._EPOCH + datetime.timedelta(seconds=t)).astimezone(tzinfo)
 
         return cls.instance(dt, tz=tzinfo)
@@ -1264,7 +1264,9 @@ class DateTime(datetime.datetime, Date):
     def utcfromtimestamp(cls, t: float) -> Self:
         try:
             dt = datetime.datetime.utcfromtimestamp(t)
-        except OSError:
+        except (OSError, OverflowError):
+            # Match datetime.datetime.utcfromtimestamp(), which returns a
+            # naive datetime representing UTC.
             dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=t)
 
         return cls.instance(dt, tz=None)

--- a/tests/datetime/test_behavior.py
+++ b/tests/datetime/test_behavior.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import datetime as datetime_
+import importlib
 import pickle
+import types
 import zoneinfo
 
 from copy import deepcopy
@@ -105,6 +108,52 @@ def test_utcfromtimestamp():
     dt = datetime.utcfromtimestamp(0)
 
     assert p == dt
+
+
+def test_fromtimestamp_falls_back_for_negative_timestamp(monkeypatch):
+    pendulum_datetime_module = importlib.import_module("pendulum.datetime")
+
+    class FakeDateTime(datetime_.datetime):
+        @classmethod
+        def fromtimestamp(cls, t: float, tz: datetime_.tzinfo | None = None):
+            if t == -43201:
+                raise OSError("Invalid argument")
+
+            return super().fromtimestamp(t, tz=tz)
+
+    monkeypatch.setattr(
+        pendulum_datetime_module,
+        "datetime",
+        types.SimpleNamespace(datetime=FakeDateTime, timedelta=datetime_.timedelta),
+    )
+
+    p = pendulum.DateTime.fromtimestamp(-43201, pendulum.UTC)
+
+    assert p == pendulum.datetime(1969, 12, 31, 11, 59, 59)
+    assert p.timezone_name == "UTC"
+
+
+def test_utcfromtimestamp_falls_back_for_negative_timestamp(monkeypatch):
+    pendulum_datetime_module = importlib.import_module("pendulum.datetime")
+
+    class FakeDateTime(datetime_.datetime):
+        @classmethod
+        def utcfromtimestamp(cls, t: float):
+            if t == -43201:
+                raise OSError("Invalid argument")
+
+            return super().utcfromtimestamp(t)
+
+    monkeypatch.setattr(
+        pendulum_datetime_module,
+        "datetime",
+        types.SimpleNamespace(datetime=FakeDateTime, timedelta=datetime_.timedelta),
+    )
+
+    p = pendulum.DateTime.utcfromtimestamp(-43201)
+
+    assert p == pendulum.naive(1969, 12, 31, 11, 59, 59)
+    assert p.tzinfo is None
 
 
 def test_fromordinal():

--- a/tests/datetime/test_behavior.py
+++ b/tests/datetime/test_behavior.py
@@ -6,6 +6,8 @@ import pickle
 import types
 import zoneinfo
 
+import pytest
+
 from copy import deepcopy
 from datetime import date
 from datetime import datetime
@@ -110,14 +112,15 @@ def test_utcfromtimestamp():
     assert p == dt
 
 
-def test_fromtimestamp_falls_back_for_negative_timestamp(monkeypatch):
+@pytest.mark.parametrize("exception_type", [OSError, OverflowError])
+def test_fromtimestamp_falls_back_for_negative_timestamp(monkeypatch, exception_type):
     pendulum_datetime_module = importlib.import_module("pendulum.datetime")
 
     class FakeDateTime(datetime_.datetime):
         @classmethod
         def fromtimestamp(cls, t: float, tz: datetime_.tzinfo | None = None):
             if t == -43201:
-                raise OSError("Invalid argument")
+                raise exception_type("Invalid argument")
 
             return super().fromtimestamp(t, tz=tz)
 
@@ -133,14 +136,15 @@ def test_fromtimestamp_falls_back_for_negative_timestamp(monkeypatch):
     assert p.timezone_name == "UTC"
 
 
-def test_utcfromtimestamp_falls_back_for_negative_timestamp(monkeypatch):
+@pytest.mark.parametrize("exception_type", [OSError, OverflowError])
+def test_utcfromtimestamp_falls_back_for_negative_timestamp(monkeypatch, exception_type):
     pendulum_datetime_module = importlib.import_module("pendulum.datetime")
 
     class FakeDateTime(datetime_.datetime):
         @classmethod
         def utcfromtimestamp(cls, t: float):
             if t == -43201:
-                raise OSError("Invalid argument")
+                raise exception_type("Invalid argument")
 
             return super().utcfromtimestamp(t)
 

--- a/tests/datetime/test_create_from_timestamp.py
+++ b/tests/datetime/test_create_from_timestamp.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import datetime as datetime_
+
 import pendulum
+import pytest
 
 from pendulum import timezone
 from tests.conftest import assert_datetime
@@ -25,28 +28,38 @@ def test_create_from_timestamp_with_timezone():
 
 
 def test_create_from_timestamp_negative():
-    """Negative timestamps earlier than 12h before the Unix epoch should work.
-
-    Regression test for issue 956: on Windows (and potentially other
-    platforms), datetime.fromtimestamp raises OSError for timestamps
-    below a platform-specific minimum.  pendulum should still return a
-    correct DateTime.
-    """
-    # -43201 is 1 second past the 12h-before-epoch boundary reported in the issue
     d = pendulum.from_timestamp(-43201)
     assert_datetime(d, 1969, 12, 31, 11, 59, 59)
     assert d.timezone_name == "UTC"
 
 
 def test_create_from_timestamp_negative_with_timezone():
-    """Negative timestamps with an explicit timezone should also work."""
     d = pendulum.from_timestamp(-43201, "America/Toronto")
     assert d.timezone_name == "America/Toronto"
     assert_datetime(d, 1969, 12, 31, 6, 59, 59)
 
 
 def test_create_from_timestamp_negative_with_microseconds():
-    """Negative float timestamps preserving microseconds."""
     d = pendulum.from_timestamp(-43201.5)
     assert_datetime(d, 1969, 12, 31, 11, 59, 58, 500000)
+    assert d.timezone_name == "UTC"
+
+
+@pytest.mark.parametrize("exception_type", [OSError, OverflowError])
+def test_create_from_timestamp_falls_back_for_negative_timestamp(
+    monkeypatch, exception_type
+):
+    class FakeDateTime(datetime_.datetime):
+        @classmethod
+        def fromtimestamp(cls, timestamp: float, tz: datetime_.tzinfo | None = None):
+            if timestamp == -43201:
+                raise exception_type("Invalid argument")
+
+            return super().fromtimestamp(timestamp, tz=tz)
+
+    monkeypatch.setattr(pendulum._datetime, "datetime", FakeDateTime)
+
+    d = pendulum.from_timestamp(-43201)
+
+    assert_datetime(d, 1969, 12, 31, 11, 59, 59)
     assert d.timezone_name == "UTC"

--- a/tests/datetime/test_create_from_timestamp.py
+++ b/tests/datetime/test_create_from_timestamp.py
@@ -22,3 +22,31 @@ def test_create_from_timestamp_with_timezone():
     d = pendulum.from_timestamp(0, timezone("America/Toronto"))
     assert d.timezone_name == "America/Toronto"
     assert_datetime(d, 1969, 12, 31, 19, 0, 0)
+
+
+def test_create_from_timestamp_negative():
+    """Negative timestamps earlier than 12h before the Unix epoch should work.
+
+    Regression test for issue 956: on Windows (and potentially other
+    platforms), datetime.fromtimestamp raises OSError for timestamps
+    below a platform-specific minimum.  pendulum should still return a
+    correct DateTime.
+    """
+    # -43201 is 1 second past the 12h-before-epoch boundary reported in the issue
+    d = pendulum.from_timestamp(-43201)
+    assert_datetime(d, 1969, 12, 31, 11, 59, 59)
+    assert d.timezone_name == "UTC"
+
+
+def test_create_from_timestamp_negative_with_timezone():
+    """Negative timestamps with an explicit timezone should also work."""
+    d = pendulum.from_timestamp(-43201, "America/Toronto")
+    assert d.timezone_name == "America/Toronto"
+    assert_datetime(d, 1969, 12, 31, 6, 59, 59)
+
+
+def test_create_from_timestamp_negative_with_microseconds():
+    """Negative float timestamps preserving microseconds."""
+    d = pendulum.from_timestamp(-43201.5)
+    assert_datetime(d, 1969, 12, 31, 11, 59, 58, 500000)
+    assert d.timezone_name == "UTC"


### PR DESCRIPTION
## Problem

`pendulum.from_timestamp()` raises on Windows 11 for timestamps earlier than approximately 12 hours before the Unix epoch (for example `-43201`).

Depending on the platform and Python build, the stdlib timestamp constructors can raise either `OSError` or `OverflowError` for these values.

The same underlying limitation also affects the public classmethods:

- `pendulum.DateTime.fromtimestamp()`
- `pendulum.DateTime.utcfromtimestamp()`

Reported in issue #956.

## Reproduction

```python
>>> pendulum.from_timestamp(-43200)
DateTime(1969, 12, 31, 12, 0, 0, tzinfo=Timezone('UTC'))

>>> pendulum.from_timestamp(-43201)
OSError: [Errno 22] Invalid argument
```

## Fix

Catch `(OSError, OverflowError)` from the stdlib timestamp constructors and fall back to computing the result from a fixed Unix epoch plus a `timedelta`.

This PR covers:

- `pendulum.from_timestamp()`
- `pendulum.DateTime.fromtimestamp()`
- `pendulum.DateTime.utcfromtimestamp()`

The fallback preserves microseconds and keeps timezone conversion behavior intact.

## Tests

Added and updated tests for:

- negative timestamps before the epoch
- explicit timezone conversion for negative timestamps
- float timestamps preserving microseconds
- forced fallback coverage for `pendulum.from_timestamp()`
- forced fallback coverage for `DateTime.fromtimestamp()`
- forced fallback coverage for `DateTime.utcfromtimestamp()`
- both `OSError` and `OverflowError` fallback paths

Targeted tests run locally:

```bash
PYTHONPATH=src pytest tests/datetime/test_create_from_timestamp.py -q
PYTHONPATH=src pytest tests/datetime/test_behavior.py -k 'test_fromtimestamp_falls_back_for_negative_timestamp or test_utcfromtimestamp_falls_back_for_negative_timestamp or test_fromtimestamp or test_utcfromtimestamp' -q
```

The full suite also passes locally on Windows 11.
