### PR TITLE
fix: correct Hindi date formats

### DIFF
--- a/src/pendulum/locales/hi/custom.py
+++ b/src/pendulum/locales/hi/custom.py
@@ -13,9 +13,9 @@ translations = {
     "date_formats": {
         "LTS": "h:mm:ss A",
         "LT": "h:mm A",
-        "L": "MM/DD/YYYY",
-        "LL": "MMMM D, YYYY",
-        "LLL": "MMMM D, YYYY h:mm A",
-        "LLLL": "dddd, MMMM D, YYYY h:mm A",
+        "L": "DD/MM/YYYY",
+        "LL": "D MMMM YYYY",
+        "LLL": "D MMMM YYYY h:mm A",
+        "LLLL": "dddd, D MMMM YYYY h:mm A",
     },
 }

--- a/tests/localization/test_hi.py
+++ b/tests/localization/test_hi.py
@@ -67,3 +67,11 @@ def diff_for_humans():
 
     assert d.diff_for_humans(d2, True, locale=locale) == "कुछ सेकंड"
     assert d2.diff_for_humans(d.add(seconds=1), True, locale=locale) == "कुछ सेकंड"
+
+
+def test_date_formats():
+    d = pendulum.datetime(2016, 8, 29, 7, 3, 6, 123456)
+    assert d.format("L", locale=locale) == "29/08/2016"
+    assert d.format("LL", locale=locale) == "29 अगस्त 2016"
+    assert d.format("LLL", locale=locale) == "29 अगस्त 2016 7:03 AM"
+    assert d.format("LLLL", locale=locale) == "सोमवार, 29 अगस्त 2016 7:03 AM"


### PR DESCRIPTION
## Summary
- correct Hindi custom date formats to use locale-appropriate day-first ordering
- remove the incorrect month-first/comma-separated Hindi `L`/`LL`/`LLL`/`LLLL` formats
- add regression coverage for Hindi date formatting tokens

## Why
Hindi locale data is day-first in CLDR/Babel, but Pendulum's custom Hindi date formats were using US-style month-first ordering. This makes Hindi inconsistent with the locale data and with runtime expectations.

## Test Plan
- [x] `PYTHONPATH=src python3 -m pytest tests/localization/test_hi.py -q`
- [x] `PYTHONPATH=src python3 -m pytest tests/localization -q`
- [x] `PYTHONPATH=src python3 -m pytest -q`
