### PR TITLE
Fix lowercase 'a' token formatting to lowercase meridiem

### DIFF
--- a/docs/docs/string_formatting.md
+++ b/docs/docs/string_formatting.md
@@ -140,6 +140,7 @@ The following tokens are currently supported:
 |                                | SSSS ...      | 000[0..] 001[0..] ... 998[0..] 999[0..]    |
 |                                | SSSSSS        |                                            |
 | **AM / PM**                    | A             | AM, PM                                     |
+|                                | a             | am, pm                                     |
 | **Timezone**                   | Z             | -07:00, -06:00 ... +06:00, +07:00          |
 |                                | ZZ            | -0700, -0600 ... +0600, +0700              |
 |                                | z             | Asia/Baku, Europe/Warsaw, GMT ...          |

--- a/src/pendulum/formatting/formatter.py
+++ b/src/pendulum/formatting/formatter.py
@@ -347,14 +347,16 @@ class Formatter:
             first_day = cast("int", locale.get("translations.week_data.first_day"))
 
             return locale.ordinalize((dt.day_of_week % 7 - first_day) % 7 + 1)
-        elif token == "A":
+        elif token in ["A", "a"]:
             key = "translations.day_periods"
             if dt.hour >= 12:
                 key += ".pm"
             else:
                 key += ".am"
 
-            return cast("str", locale.get(key))
+            meridiem = cast("str", locale.get(key))
+
+            return meridiem.lower() if token == "a" else meridiem
         else:
             return token
 

--- a/tests/formatting/test_formatter.py
+++ b/tests/formatting/test_formatter.py
@@ -140,6 +140,13 @@ def test_am_pm():
     assert f.format(d.set(hour=11), "A") == "AM"
 
 
+def test_lowercase_am_pm():
+    f = Formatter()
+    d = pendulum.datetime(2016, 8, 28, 23)
+    assert f.format(d, "a") == "pm"
+    assert f.format(d.set(hour=11), "a") == "am"
+
+
 def test_hour():
     f = Formatter()
     d = pendulum.datetime(2016, 8, 28, 7)


### PR DESCRIPTION
The `a` format token returns the literal string `a` instead of a lowercase meridiem indicator (am/pm).

```python
>>> import pendulum
>>> dt = pendulum.datetime(2016, 8, 28, 23)
>>> dt.format("A")
'PM'
>>> dt.format("a")   # expected 'pm'
'a'
```

`_format_localizable_token` only handles the uppercase `A` token, so `a` falls through to the default branch that returns the token unchanged. The `a` token is documented and registered in the token regex, and the parser side already treats it as a lowercase meridiem, so formatting and parsing were inconsistent and a value formatted with `a` could not be round-tripped:

```python
>>> pendulum.from_format(dt.format("YYYY-MM-DD hh:mm a"), "YYYY-MM-DD hh:mm a")
```

previously failed because the formatted string contained a literal `a` rather than `pm`.

This mirrors the existing `A` branch and lowercases the result for the `a` token. Added a regression test alongside the existing `test_am_pm`.